### PR TITLE
Allow groups without address and custom distance units

### DIFF
--- a/exportGroupMembers.py
+++ b/exportGroupMembers.py
@@ -24,6 +24,10 @@ for grp in groupsList["data"]:
     groupAddress = grpLocation["data"]["attributes"]["full_formatted_address"].replace("\n", ", ")
     groupLong = grpLocation["data"]["attributes"]["longitude"]
     groupLat = grpLocation["data"]["attributes"]["latitude"]
+  else:
+    groupAddress = ""
+    groupLong = ""
+    groupLat = ""
 
   for member in members["data"]:
     # try:
@@ -39,7 +43,11 @@ for grp in groupsList["data"]:
           address["attributes"]["state"] if address["attributes"]["state"] != None else '',
           address["attributes"]["zip"] if address["attributes"]["zip"] != None else ''))
         mapLocation = mapApi.getLocation()
-        memberDistance = distance.distance((groupLat, groupLong),(mapLocation["lat"], mapLocation["lng"])).miles
+        if grpLocation != None:
+          distanceUnit = config.UNIT if hasattr(config, 'UNIT') else 'miles'
+          memberDistance = eval('distance.distance((groupLat, groupLong),(mapLocation["lat"], mapLocation["lng"])).' + distanceUnit)
+        else:
+          memberDistance = ""
 
       outputFile.write(csvPlaceholder % (
         person["data"]["attributes"]["first_name"],

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,12 @@ API_PASSWORD = 'specify your password'
 GOOGLE_APIKEY = 'specify your Google API key'
 ```
 
+Optionally, you can also specify the unit distance used in the calculations (default is miles, available options listed [here](https://geopy.readthedocs.io/en/stable/#geopy.point.Point.from_string)):
+
+```
+UNIT = 'km'
+```
+
 Learn how to obtain a [Google API Key](https://developers.google.com/maps/documentation/geocoding/get-api-key).
 
 _**NOTE** The config.py file is ignored by git._


### PR DESCRIPTION
Hi David, thanks for putting this together!

I've had a few exceptions due to some groups not having defined addresses, so this aims at allowing the script to move on in those cases.

Apart from that we use km instead of miles in Australia, so I thought this could be an addition too. :)

I'm not a full developer myself so happy to have these suggestions implemented in a different way.